### PR TITLE
Fix CRC16::_update

### DIFF
--- a/CRC16.cpp
+++ b/CRC16.cpp
@@ -66,7 +66,7 @@ uint16_t CRC16::getCRC()
 void CRC16::_update(uint8_t value)
 {
   if (!_started) restart();
-  if (_reverseIn) value = _reverse(value);
+  if (_reverseIn) value = _reverse8(value);
   _crc ^= ((uint16_t)value) << 8;;
   for (uint8_t i = 8; i; i--) 
   {
@@ -90,6 +90,15 @@ uint16_t CRC16::_reverse(uint16_t in)
   x = (((x & 0xCCCC) >> 2) | ((x & 0X3333) << 2));
   x = (((x & 0xF0F0) >> 4) | ((x & 0X0F0F) << 4));
   x = (( x >> 8) | (x << 8));
+  return x;
+}
+
+uint8_t CRC16::_reverse8(uint8_t in)
+{
+  uint8_t x = in;
+  x = (((x & 0xAA) >> 1) | ((x & 0x55) << 1));
+  x = (((x & 0xCC) >> 2) | ((x & 0x33) << 2));
+  x =          ((x >> 4) | (x << 4));
   return x;
 }
 

--- a/CRC16.h
+++ b/CRC16.h
@@ -35,6 +35,7 @@ public:
 
 private:
   uint16_t _reverse(uint16_t value);
+  uint8_t  _reverse8(uint8_t value);
   void     _update(uint8_t value);
 
   uint16_t _polynome;


### PR DESCRIPTION
This PR fixes an issue in the CRC16::_update method where a `uint16_t reverse(uint16_t)` function is used instead of the correct `uint8_t reverse(uint8_t)`.

Copied a `_reverse8()` method from `CRC.h`.
