### PR TITLE
add extra Header Guards

### DIFF
--- a/CRC.h
+++ b/CRC.h
@@ -1,8 +1,10 @@
 #pragma once
+#ifndef CRC_H
+#define CRC_H
 //
 //    FILE: CRC.h
 //  AUTHOR: Rob Tillaart
-// VERSION: 0.2.2
+// VERSION: 0.2.3
 // PURPOSE: Arduino library for CRC8, CRC12, CRC16, CRC16-CCITT, CRC32, CRC64
 //     URL: https://github.com/RobTillaart/CRC
 //
@@ -12,7 +14,7 @@
 
 #include "CRC_polynomes.h"
 
-#define CRC_LIB_VERSION       (F("0.2.2"))
+#define CRC_LIB_VERSION       (F("0.2.3"))
 
 
 ////////////////////////////////////////////////////////////////
@@ -230,4 +232,4 @@ uint64_t crc64(const uint8_t *array, uint16_t length, const uint64_t polynome = 
 
 
 // -- END OF FILE --
-
+#endif

--- a/CRC12.h
+++ b/CRC12.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CRC12_H
+#define CRC12_H
 //
 //    FILE: CRC12.h
 //  AUTHOR: Rob Tillaart
@@ -63,4 +65,4 @@ private:
 
 
 // -- END OF FILE --
-
+#endif

--- a/CRC16.h
+++ b/CRC16.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CRC16_H
+#define CRC16_H
 //
 //    FILE: CRC16.h
 //  AUTHOR: Rob Tillaart
@@ -62,4 +64,4 @@ private:
 
 
 // -- END OF FILE --
-
+#endif

--- a/CRC32.h
+++ b/CRC32.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CRC32_H
+#define CRC32_H
 //
 //    FILE: CRC32.h
 //  AUTHOR: Rob Tillaart
@@ -62,4 +64,4 @@ private:
 
 
 // -- END OF FILE --
-
+#endif

--- a/CRC64.h
+++ b/CRC64.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CRC64_H
+#define CRC64_H
 //
 //    FILE: CRC64.h
 //  AUTHOR: Rob Tillaart
@@ -9,7 +11,6 @@
 #include "Arduino.h"
 
 #include "CRC_polynomes.h"
-
 
 
 class CRC64
@@ -63,4 +64,4 @@ private:
 
 
 // -- END OF FILE --
-
+#endif

--- a/CRC8.h
+++ b/CRC8.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CRC8_H
+#define CRC8_H
 //
 //    FILE: CRC8.h
 //  AUTHOR: Rob Tillaart
@@ -61,4 +63,4 @@ private:
 
 
 // -- END OF FILE --
-
+#endif

--- a/CRC_polynomes.h
+++ b/CRC_polynomes.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CRC_POLYNOMES_H
+#define CRC_POLYNOMES_H
 //
 //    FILE: polynomes.h
 //  AUTHOR: Rob Tillaart
@@ -65,4 +67,4 @@
 
 
 // -- END OF FILE --
-
+#endif

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,11 +1,13 @@
 # Syntax Colouring Map For CRC
 
+
 # Data types (KEYWORD1)
 CRC8	KEYWORD1
 CRC12	KEYWORD1
 CRC16	KEYWORD1
 CRC32	KEYWORD1
 CRC64	KEYWORD1
+
 
 # Methods and Functions (KEYWORD2)
 crc8	KEYWORD2

--- a/library.json
+++ b/library.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "https://github.com/RobTillaart/CRC"
   },
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "MIT",
   "frameworks": "arduino",
   "platforms": "*",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=CRC
-version=0.2.2
+version=0.2.3
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Library for CRC for Arduino

--- a/releaseNotes.md
+++ b/releaseNotes.md
@@ -2,6 +2,11 @@
 # Release Notes
 
 
+## 0.2.3  2022-04-13
+
+- replace #pragma once with #ifndef Header guards
+
+
 ## 0.2.2
 
 - fix #19 enable/disable yield call


### PR DESCRIPTION
As not all compilers support #pragma once, extra Header Guards are added to keep it compiling
See #21 